### PR TITLE
Russian language fixed

### DIFF
--- a/templates/sidebar.html.twig
+++ b/templates/sidebar.html.twig
@@ -86,7 +86,7 @@
                                 <a class="{% if not app.request.get('overlay') %}block {% endif %}px-2 py-2 mt-2 text-white text-sm font-semibold"
                                    href="{{ path(app.request.attributes.get('_route'), {_locale: 'fr'}) }}">Français</a>
                                 <a class="{% if not app.request.get('overlay') %}block {% endif %}px-2 py-2 mt-2 text-white text-sm font-semibold"
-                                   href="{{ path(app.request.attributes.get('_route'), {_locale: 'ru'}) }}">русский</a>
+                                   href="{{ path(app.request.attributes.get('_route'), {_locale: 'ru'}) }}">Русский</a>
                                 <a class="{% if not app.request.get('overlay') %}block {% endif %}px-2 py-2 mt-2 text-white text-sm font-semibold"
                                    href="{{ path(app.request.attributes.get('_route'), {_locale: 'pl'}) }}">Polskie</a>
                             </div>


### PR DESCRIPTION
This should be "Русский" with a capital letter, not "русский"
![image](https://user-images.githubusercontent.com/63174820/145268954-263db1fe-3cd6-4cf2-a163-73d1d59a780e.png)
Before