### PR TITLE
Remove language update on Twitch Provider

### DIFF
--- a/src/Provider/TwitchProvider.php
+++ b/src/Provider/TwitchProvider.php
@@ -64,8 +64,7 @@ class TwitchProvider extends AbstractPlatformProvider
                     ],
                     'json' => [
                         'game_id' => $category,
-                        'title' => $title,
-                        'broadcaster_language' => 'fr'
+                        'title' => $title
                     ]
                 ]
             );


### PR DESCRIPTION
User may stream in a language that's not implemented, as this parameter is optionnal I think we should just remove it.

Fix https://github.com/artandor/multistream-tools/issues/28